### PR TITLE
Update trim function (Fix #28)

### DIFF
--- a/scss/api/_trim.scss
+++ b/scss/api/_trim.scss
@@ -1,81 +1,38 @@
-@function __trimmed-left-index($string) {
-    $index: 1;
-    $length: str-length($string);
-
-    @while ($index <= $length) and (__is-space(__char-at($string, $index))) {
-        $index: $index + 1;
-    }
-
-    @return $index;
-}
-
-
-@function __trimmed-right-index($string) {
-    $index: str-length($string);
-
-    @while ($index > 0) and (__is-space(__char-at($string, $index))) {
-        $index: $index - 1;
-    }
-
-    @return $index;
-}
-
-
 @function __trim($string, $chars: null, $guard: null) {
-    $value: $string;
-    $string: __base-to-string($string);
+    $string: __trim-left($string, $chars, $guard);
+    $string: __trim-right($string, $chars, $guard);
 
-    @if not ($string) or ($string == '') or ($chars == '') {
-        @return $string;
-    }
-
-    @if (if($guard, __is-iteratee-call($value, $chars, $guard), ($chars == null))) {
-        @return str-slice($string, __trimmed-left-index($string), __trimmed-right-index($string));
-    }
-
-    $chars: __base-to-string($chars);
-
-    @return str-slice($string,
-        __chars-left-index($string, $chars),
-        __chars-right-index($string, $chars));
+    @return $string;
 }
-
 
 @function __trim-left($string, $chars: null, $guard: null) {
-    $value: $string;
-    $string: __base-to-string($string);
-
-    @if not ($string) or ($string == '') or ($chars == '') {
-        @return $string;
+    @if $guard {
+        @return __trim-left($string);
     }
 
-    @if (if($guard, __is-iteratee-call($value, $chars, $guard), ($chars == null))) {
-        @return str-slice($string, __trimmed-left-index($string));
+    $string: __to-string($string);
+    $chars-list: __string-split(if($chars, __to-string($chars), ' '));
+
+    @while index($chars-list, str-slice($string, 0, 1)) != null {
+        $string: str-slice($string, 2);
     }
 
-    $chars: __base-to-string($chars);
-
-    @return str-slice($string,
-        __chars-left-index($string, $chars));
+    @return $string;
 }
 
-
 @function __trim-right($string, $chars: null, $guard: null) {
-    $value: $string;
-    $string: __base-to-string($string);
-
-    @if not ($string) or ($string == '') or ($chars == '') {
-        @return $string;
+    @if $guard {
+        @return __trim-right($string);
     }
 
-    @if (if($guard, __is-iteratee-call($value, $chars, $guard), ($chars == null))) {
-        @return str-slice($string, 0, __trimmed-right-index($string));
+    $string: __to-string($string);
+    $chars-list: __string-split(if($chars, __to-string($chars), ' '));
+
+    @while index($chars-list, str-slice($string, -1)) != null {
+        $string: str-slice($string, 0, -2);
     }
 
-    $chars: __base-to-string($chars);
-
-    @return str-slice($string, 0,
-        __chars-right-index($string, $chars));
+    @return $string;
 }
 
 


### PR DESCRIPTION
This update allows the trim functions to accept multiple specified characters. For example: 

```
_trim("-_-abc-_-", "a_-")  => "bc"
```

All tests are passed, but I am not sure if there are any side effects, so please review carefully.

BTW, some char helper functions are now unused, such as `__is-space`, `__chars-index`.