### PR TITLE
feat: Remove unnecessary !global to avoid sass warning prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /tests/*.map
 /tests/.sass-cache
 index.html
+.history

--- a/scss/api/_context.scss
+++ b/scss/api/_context.scss
@@ -1,4 +1,4 @@
-$__context__: () !global;
+$__context__: ();
 
 @mixin __context($context: (), $callback: '__identity') {
   $parent-context: $__context__;

--- a/scss/api/_memoize.scss
+++ b/scss/api/_memoize.scss
@@ -1,4 +1,4 @@
-$__memoized__: () !global;
+$__memoized__: ();
 
 @function __memoize-memoized($arguments...) {
     $func: __this('func');

--- a/scss/constants/_global.scss
+++ b/scss/constants/_global.scss
@@ -1,4 +1,4 @@
-$__const__: () !global;
+$__const__: ();
 
 @function __const($keys) {
     @return __get($__const__, $keys);

--- a/scss/helpers/_scope.scss
+++ b/scss/helpers/_scope.scss
@@ -1,5 +1,5 @@
 $__current-scope__: null !global;
-$__undefined__: '__undefined-#{unique-id()}__' !global;
+$__undefined__: '__undefined-#{unique-id()}__';
 
 @function Scope($parent: $__current-scope__) {
     $scope-id: unquote('@#{unique-id()}');

--- a/scss/static/_static.scss
+++ b/scss/static/_static.scss
@@ -1,4 +1,4 @@
-$__static__: () !global;
+$__static__: ();
 
 ///
 /// Gets the specified static variable. Uses `_get()` syntax.


### PR DESCRIPTION
Mainly modify this  #45 
